### PR TITLE
Fix Indonesia reference

### DIFF
--- a/osmBoundarySources.json
+++ b/osmBoundarySources.json
@@ -546,7 +546,7 @@
     "timezone": "America/Indiana/Indianapolis"
   },
   "Indonesia": {
-    "ISO3166-1": "ID"
+    "name": "Indonesia"
   },
   "Iran": {
     "ISO3166-1": "IR"


### PR DESCRIPTION
```
getting data for Indonesia
downloading from overpass
waiting 4 seconds
Success, decreasing overpass request gap
done
error! Error: Invalid geojson for boundary: Indonesia
```
