### PR TITLE
Proposed fix for the analyze step

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,4 +87,5 @@ $RECYCLE.BIN/
 # Project
 # =========================
 downloads
+working
 dist


### PR DESCRIPTION
This commit avoids the hardcoded use of the ./dist directory in the diff
anaysis step, instead using the directory specified via a new
--working_dir flag. Without this, the ./dist directory is always used
(if it exists, otherwise failure).

The "dist/dist/" repeat has also been removed because it should no
longer be required.

This commit could have used the `distDir` variable instead, but a new
"working_dir" flag has been introduced instead. A generic name has been
chosen to enable its use for things besides diff analysis later if
needed. It's possible that several files in "dist" could be moved there
later if they're not needed in the distribution, but this has not been
attempted here.

I feel a new directory is reasonable because the files associated with
the previous release don't naturally fit with "downloads" (i.e. files
from OSM) or "dist" (the new distribution). In Android in the future, we
may commit dist + download for change history, but committing the
previous release file seems redundant as it also lives in dist/ under a
previous commit.

The flags documentation has been adjusted to try to make the
distinctions between directories clearer.