### PR TITLE
Fix timezone namechange in America/North_Dakota

### DIFF
--- a/osmBoundarySources.json
+++ b/osmBoundarySources.json
@@ -144,13 +144,13 @@
     "timezone": "America/Nipigon"
   },
   "America-North_Dakota-Beulah-tz": {
-    "timezone": "America-North_Dakota-Beulah-tz"
+    "timezone": "America/North_Dakota/Beulah"
   },
   "America-North_Dakota-Center-tz": {
-    "timezone": "America-North_Dakota-Center-tz"
+    "timezone": "America/North_Dakota/Center"
   },
   "America-North_Dakota-New_Salem-tz": {
-    "timezone": "America-North_Dakota-New_Salem-tz"
+    "timezone": "America/North_Dakota/New_Salem"
   },
   "America-Ojinaga-tz": {
     "timezone": "America/Ojinaga"


### PR DESCRIPTION
Confirmed working with overpass API. Without this change, a
`No data for the following query` would be thrown.

**TLDR**
Looks like a copy-paste error introduced here: https://github.com/evansiroky/timezone-boundary-builder/commit/a2014a940c06b0ee6f6dcd67c5fd22da6219f7df

**Issue**
```
getting data for America-North_Dakota-Beulah-tz; Downloading progress: 11.5% done - 1.2 hours left
downloading from overpass
waiting 8 seconds
query [out:json][timeout:60];(relation["timezone"="America-North_Dakota-Beulah-tz"];);out body;>;out meta qt;
Success, decreasing overpass request gap
No data for the following query:
[out:json][timeout:60];(relation["timezone"="America-North_Dakota-Beulah-tz"];);out body;>;out meta qt;
To read more about this error, please visit https://git.io/vxKQL
done
error! Error: No data found for from overpass query
    at asynclib.auto.validateOverpassResult (/Users/tzaman/dev/timezone-boundary-builder/index.js:338:19)
    at runTask (/Users/tzaman/dev/timezone-boundary-builder/node_modules/async/dist/async.js:1150:17)
    at /Users/tzaman/dev/timezone-boundary-builder/node_modules/async/dist/async.js:1088:35
    at processQueue (/Users/tzaman/dev/timezone-boundary-builder/node_modules/async/dist/async.js:1098:17)
    at taskComplete (/Users/tzaman/dev/timezone-boundary-builder/node_modules/async/dist/async.js:1115:13)
    at /Users/tzaman/dev/timezone-boundary-builder/node_modules/async/dist/async.js:1143:21
    at /Users/tzaman/dev/timezone-boundary-builder/node_modules/async/dist/async.js:324:20
    at overpassResponseHandler (/Users/tzaman/dev/timezone-boundary-builder/index.js:310:13)
    at overpass.flatProperties (/Users/tzaman/dev/timezone-boundary-builder/index.js:320:30)
    at Stream.toGeoJSON (/Users/tzaman/dev/timezone-boundary-builder/node_modules/query-overpass/index.js:18:9)
```
The statement `` is confirmed not returning data through overpass turbo, but `[out:json][timeout:60];(relation["timezone"="America/North_Dakota/New_Salem"];);out body;>;out meta qt;` is; link for proof: https://overpass-turbo.eu/s/1kTq


