### PR TITLE
Update tz name for Ukraine

### DIFF
--- a/timezones.json
+++ b/timezones.json
@@ -3408,7 +3408,7 @@
       "id": "Kaliningrad"
     }
   ],
-  "Europe/Kiev": [
+  "Europe/Kyiv": [
     {
       "op": "init",
       "source": "overpass",


### PR DESCRIPTION
I believe it's most appropriate to use `Europe/Kyiv` for Ukraine, now that IANA has added this (in 2022b).

Thanks.