### PR TITLE
Update timezone names with OSM relation names, fix some in osmBoundarySources.json

### DIFF
--- a/osmBoundarySources.json
+++ b/osmBoundarySources.json
@@ -140,17 +140,14 @@
   "America-New_York-tz": {
     "timezone": "America/New_York"
   },
-  "America-Nipigon-tz": {
-    "timezone": "America/Nipigon"
-  },
   "America-North_Dakota-Beulah-tz": {
-    "timezone": "America-North_Dakota-Beulah-tz"
+    "timezone": "America/North_Dakota/Beulah"
   },
   "America-North_Dakota-Center-tz": {
-    "timezone": "America-North_Dakota-Center-tz"
+    "timezone": "America/North_Dakota/Center"
   },
   "America-North_Dakota-New_Salem-tz": {
-    "timezone": "America-North_Dakota-New_Salem-tz"
+    "timezone": "America/North_Dakota/New_Salem"
   },
   "America-Ojinaga-tz": {
     "timezone": "America/Ojinaga"
@@ -160,9 +157,6 @@
   },
   "America-Phoenix-tz": {
     "timezone": "America/Phoenix"
-  },
-  "America-Rainy_River-tz": {
-    "timezone": "America/Rainy_River"
   },
   "America-Rankin_Inlet-tz": {
     "timezone": "America/Rankin_Inlet"
@@ -178,9 +172,6 @@
   },
   "America-Swift_Current-tz": {
     "timezone": "America/Swift_Current"
-  },
-  "America-Thunder_Bay-tz": {
-    "timezone": "America/Thunder_Bay"
   },
   "America-Toronto-tz": {
     "timezone": "America/Toronto"

--- a/timezones.json
+++ b/timezones.json
@@ -937,7 +937,7 @@
   ],
   "America/Edmonton": [
     {
-      "op": "union",
+      "op": "init",
       "source": "overpass",
       "id": "America-Edmonton-tz"
     }
@@ -1440,13 +1440,6 @@
       "description": "Add areas in Alabama near Phenix City and Lanett that observe eastern time.  The boundaries are a speculative guess."
     }
   ],
-  "America/Nipigon": [
-    {
-      "op": "init",
-      "source": "overpass",
-      "id": "America-Nipigon-tz"
-    }
-  ],
   "America/Nome": [
     {
       "op": "init",
@@ -1592,13 +1585,6 @@
       "source": "manual-polygon",
       "data": [[[-64,-64],[-57.3,-63.4],[-58.8,-62.25],[-59,-61.8],[-63,-62.7],[-64,-64]]],
       "description": "Add Antarctic Areas.  Includes stations General Bernardo O'Higgins, Great Wall, Bellinghausen and Artigas."
-    }
-  ],
-  "America/Rainy_River": [
-    {
-      "op": "init",
-      "source": "overpass",
-      "id": "America-Rainy_River-tz"
     }
   ],
   "America/Rankin_Inlet": [
@@ -1823,13 +1809,6 @@
       "description": "Grab part of Greenland and make a best guess at this timezone's location."
     }
   ],
-  "America/Thunder_Bay": [
-    {
-      "op": "init",
-      "source": "overpass",
-      "id": "America-Thunder_Bay-tz"
-    }
-  ],
   "America/Tijuana": [
     {
       "op": "init",
@@ -1862,7 +1841,7 @@
   ],
   "America/Vancouver": [
     {
-      "op": "union",
+      "op": "init",
       "source": "overpass",
       "id": "America-Vancouver-tz"
     }


### PR DESCRIPTION
**Removed**: America/Rainy_River, America/Nipigon and America/Thunder_Bay. They have been removed from OSM. See also #131 .
**Changed**: America/North_Dakota/* to their OSM names

Also changes some `"op": "union"` that had been left where it should have been `"op": "init"` as it is the only operation, this is necessary for the script to run correctly.