### PR TITLE
Add Perl module Geo::Location::TimeZoneFinder

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ A few common languages already have libraries with an API that can be used to lo
 | JavaScript (node.js and in browser) | [tz-lookup](https://github.com/darkskyapp/tz-lookup-oss) |
 | Julia | [TimeZoneFinder](https://github.com/tpgillam/TimeZoneFinder.jl)|
 | .NET | [GeoTimezone](https://github.com/mj1856/GeoTimeZone)|
+| Perl | [Geo::Location::TimeZoneFinder](https://github.com/voegelas/Geo-Location-TimeZoneFinder)|
 | php | [Geo-Timezone](https://github.com/minube/geo-timezone)|
 | Python | [timezonefinder](https://github.com/MrMinimal64/timezonefinder)|
 | Python | [tzfpy](https://github.com/ringsaturn/tzfpy) |


### PR DESCRIPTION
I've written the Perl module [Geo::Location::TimeZoneFinder](https://metacpan.org/pod/Geo::Location::TimeZoneFinder). The module uses the timezones.shapefile.zip file published by the Timezone Boundary Builder project. This pull requests adds a link to [my GitHub project](https://github.com/voegelas/Geo-Location-TimeZoneFinder) to your README.md file.