### PR TITLE
Add browser-geo-tz to implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ A few common languages already have libraries with an API that can be used to lo
 | JavaScript (node.js only) | [node-geo-tz](https://github.com/evansiroky/node-geo-tz/)|
 | JavaScript (node.js and in browser) | [timespace](https://github.com/mapbox/timespace)|
 | JavaScript (node.js and in browser) | [tz-lookup](https://github.com/darkskyapp/tz-lookup-oss) |
+| JavaScript (browser only) | [browser-geo-tz](https://github.com/kevmo314/browser-geo-tz/)|
 | Julia | [TimeZoneFinder](https://github.com/tpgillam/TimeZoneFinder.jl)|
 | .NET | [GeoTimezone](https://github.com/mj1856/GeoTimeZone)|
 | Perl | [Geo::Location::TimeZoneFinder](https://github.com/voegelas/Geo-Location-TimeZoneFinder)|


### PR DESCRIPTION
I made a fork of node-geo-tz to run strictly in the browser. For my use case, 27MB of data is very acceptable to be downloaded by the user. It's a niche use case, but hopefully it can be of use to someone :)