### PR TITLE
Skip OSM zone shapefile creation if given skip_shapefile

### DIFF
--- a/index.js
+++ b/index.js
@@ -1087,7 +1087,7 @@ const autoScript = {
     )
   }],
   makeOSMTimezoneShapefile: ['mergeOSMZones', function (results, cb) {
-    if (argv.skip_analyze_osm_tz_diffs) {
+    if (argv.skip_analyze_osm_tz_diffs || argv.skip_shapefile) {
       overallProgress.beginTask('Skipping OSM zone shapefile creation')
       return cb()
     }


### PR DESCRIPTION
If you use --skip_shapefile argument it will also skip OSM zone shapefile creation without skipping other OSM analyze steps.
This was causing problems when ogr2ogr was not installed and a shapefile was not needed.