### PR TITLE
Added BigQuery links to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Another common way to use the data for lookup purposes is to load the shapefile 
 
 | Data Warehouse | Public Dataset |
 | -- | -- |
-| BigQuery | `tz-data` ([EU](https://console.cloud.google.com/bigquery?page=table&p=tz-data&d=latest_EU&t=timezones) or [US](https://console.cloud.google.com/bigquery?page=table&p=tz-data&d=latest_US&t=timezones))|
+| BigQuery | [tz-data](https://github.com/redorkulated/bigquery-tz-data) |
 
 ## Running the script
 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,10 @@ A few common languages already have libraries with an API that can be used to lo
 
 Another common way to use the data for lookup purposes is to load the shapefile into a spatially-aware database.  See this [blog post](https://simonwillison.net/2017/Dec/12/location-time-zone-api/) for an example of how that can be done.
 
+| Data Warehouse | Public Dataset |
+| -- | -- |
+| BigQuery | `tz-data` ([EU](https://console.cloud.google.com/bigquery?page=table&p=tz-data&d=latest_EU&t=timezones) or [US](https://console.cloud.google.com/bigquery?page=table&p=tz-data&d=latest_US&t=timezones))|
+
 ## Running the script
 
 If the data in the releases are not sufficiently recent or you want to build the latest from master, it is possible to run the script to generate the timezones.  However, due to the ever-changing nature of OpenStreetMap, the script should be considered unstable.  The script frequently breaks when unexpected data is received or changes in OpenStreetMap cause validation issues.  Please see the [troubleshooting guide](https://github.com/evansiroky/timezone-boundary-builder/wiki/Troubleshooting) for help with common errors.


### PR DESCRIPTION
Added links to a public BigQuery dataset of this timezone data. This data can then be queried using the built-in geometry functions to lookup at lat/long to a timezone. This has been super valuable to have this boundary data over the years, so it is great to have it shared with a wider audience too. 

For example, will return `Europe/London` :
```
SELECT timezone_id FROM `tz-data.latest_EU.timezones` WHERE ST_WITHIN(ST_GEOGPOINT(/* longitude */ -0.13948559859956436,/* latitude */ 51.5029659891868),geometry);
```