### PR TITLE
Handle null transitions as no transitions

### DIFF
--- a/index.js
+++ b/index.js
@@ -150,13 +150,11 @@ function getZoneCfgSinceTime (cutoffTime, cacheFilename) {
     const timezoneInstance = time.Timezone.from(zone)
     const currentZoneOffset = timezoneInstance.getOffsetForWallTime(timezoneInstance)
     let timekeepingKey = `${currentZoneOffset}`
-    const transitions = timezoneInstance.getAllTransitions()
+    // Offset-only zones (Etc/UTC, Etc/GMT-3, etc) return null instead of an empty list
+    const transitions = timezoneInstance.getAllTransitions() || []
 
-    if (transitions) {
-      // timezone with transitions between daylight savings and standard time since cutoff time
-      const futureTransitionsHash = hashMd5(transitions.filter(t => t.transitionTime > cutoffTime))
-      timekeepingKey = `${currentZoneOffset}-${futureTransitionsHash}`
-    }
+    const futureTransitionsHash = hashMd5(transitions.filter(t => t.transitionTime > cutoffTime))
+    timekeepingKey = `${currentZoneOffset}-${futureTransitionsHash}`
 
     if (!timekeepingPatternZones[timekeepingKey]) {
       timekeepingPatternZones[timekeepingKey] = []


### PR DESCRIPTION
Fixed-offset timezones (`Etc/*`) return `null` for `getTransitions()`. This breaks deduplication, as they don't get deduplicated against timezones with the same offset that have no future transitions.

Currently there's a slice of Antarctica in `combined-now` that uses `Etc/UTC`, with this PR this gets merged into `Africa/Abidjan`. This makes the set of timezones in `combined-now` a subset of TZDB's `zonenow.tab`.